### PR TITLE
Fix/map change after goto menu

### DIFF
--- a/Assets/02. Scripts/HelperScripts/Singleton.cs
+++ b/Assets/02. Scripts/HelperScripts/Singleton.cs
@@ -4,7 +4,10 @@ public class Singleton<T> : MonoBehaviour where T : MonoBehaviour
 {
     private static T _instance;
     private static bool _isMissing = false;
-    public static bool HasInstance => _instance != null;
+    // 제네릭 타입 T에서 != null은 C# 기본 참조 비교를 사용해 파괴된 Unity 오브젝트를 null로 인식하지 못함.
+    // UnityEngine.Object로 캐스팅해 Unity의 오버로드된 연산자를 강제 사용.
+    private static bool IsUnityAlive => (UnityEngine.Object)(object)_instance != null;
+    public static bool HasInstance => IsUnityAlive;
     protected virtual bool PersistAcrossScenes => true;
 
     public static T Instance
@@ -12,10 +15,10 @@ public class Singleton<T> : MonoBehaviour where T : MonoBehaviour
         get
         {
             //Lazy Initialization
-            if (_instance == null && !_isMissing)
+            if (!IsUnityAlive && !_isMissing)
             {
                 _instance = FindAnyObjectByType<T>();
-                if (_instance == null)
+                if ((UnityEngine.Object)(object)_instance == null)
                 {
                     Debug.LogError($"씬에 {typeof(T).Name} 이 없습니다. 하이어라키 창에 올려주세요.");
                     _isMissing = true;
@@ -27,7 +30,7 @@ public class Singleton<T> : MonoBehaviour where T : MonoBehaviour
 
     protected virtual void Awake()
     {
-        if (_instance != null && _instance != this)
+        if (IsUnityAlive && _instance != this)
         {
             Destroy(gameObject);
             return;

--- a/Assets/02. Scripts/Map/MapManager.cs
+++ b/Assets/02. Scripts/Map/MapManager.cs
@@ -308,6 +308,7 @@ public class MapManager : MonoBehaviour
         group.CurrentActivePath.transform.SetParent(transform);
 
         // PlayEnter 내부에서 위로 올린 뒤 내려오는 애니메이션 처리
-        _mapChangeEffect?.PlayEnter(group.CurrentActivePath, finalPosition);
+        if (_mapChangeEffect != null)
+            _mapChangeEffect.PlayEnter(group.CurrentActivePath, finalPosition);
     }
 }

--- a/Assets/02. Scripts/Stage/StageLoader.cs
+++ b/Assets/02. Scripts/Stage/StageLoader.cs
@@ -17,8 +17,6 @@ public class StageLoader : Singleton<StageLoader>
     private PlayerController _playerController;
     [SerializeField]
     private PlayerProperties _playerProperties;
-    [SerializeField]
-    private MapChangeEffect _mapChangeEffect;
 
     // stageNumber(1-based) -> pre-instantiated stage instance
     private Dictionary<int, GameObject> _stageInstances = new Dictionary<int, GameObject>();
@@ -127,7 +125,11 @@ public class StageLoader : Singleton<StageLoader>
         if (mapManager != null)
         {
             stageManager.SetMapManager(mapManager);
-            mapManager.SetMapChangeEffect(_mapChangeEffect);
+            // VFXManager는 DontDestroyOnLoad 싱글톤이므로, 씬 재로드 시 PlayStage에서
+            // 새로 생성된 VFXManager 복사본이 즉시 파괴됨. 인스펙터 참조(_mapChangeEffect)는
+            // 파괴된 복사본을 가리키게 되므로, 살아있는 싱글톤에서 직접 가져옴.
+            MapChangeEffect effect = VFXManager.Instance?.GetComponentInChildren<MapChangeEffect>(true);
+            mapManager.SetMapChangeEffect(effect);
             mapManager.ResetState();
         }
 

--- a/Assets/02. Scripts/Tutorial/TutorialManager.cs
+++ b/Assets/02. Scripts/Tutorial/TutorialManager.cs
@@ -43,13 +43,13 @@ public class TutorialManager : MonoBehaviour
     public bool ShouldShowTutorial()
     {
         //디버깅용
-        int stageNumber = GameSaveManager.Instance.CurrentStageNumber;
-        bool isTutorialStage = stageNumber == 1 || stageNumber == 0;
-        return isTutorialStage && !GameSaveManager.Instance.HasCompletedTutorial();
+        //int stageNumber = GameSaveManager.Instance.CurrentStageNumber;
+        //bool isTutorialStage = stageNumber == 1 || stageNumber == 0;
+        //return isTutorialStage && !GameSaveManager.Instance.HasCompletedTutorial();
 
         //실제용
-        //return GameSaveManager.Instance.CurrentStageNumber == 1
-        //    && !GameSaveManager.Instance.HasCompletedTutorial();
+        return GameSaveManager.Instance.CurrentStageNumber == 1
+        && !GameSaveManager.Instance.HasCompletedTutorial();
     }
 
     /// <summary>


### PR DESCRIPTION
## 🏷️ 작업 타입
- [ ] Init     (프로젝트 초기 세팅)
- [ ] Feat     (새로운 기능 추가)
- [x] Fix      (버그 수정)
- [ ] Refactor (기능 변경 없는 코드 구조 개선)
- [ ] Chore    (빌드 설정, 패키지 매니저, 기타 유지보수)

## 📝 작업 개요
> 스테이지에서 나갔다가 다시 들어온 경우 맵 교체 로직이 정상적으로 실행되지 않는 버그 수정

## 🛠️ 상세 내용
- 원인 : 플레이 도중 나가는 경우 VFXManager이 destroy 되는데, 다시 들어온 경우` fake null` 과 `?` 연산자 때문에 C# 컴파일러는 해당 오브젝트가 있다고 판단 -> 실제로는 해당 오브젝트가 없는데도 null 조건문을 빠져나오므로 버그 발생
- 해결1 : 맵이 있는지 검사할 때 `?`를 빼고` if  !=` 연산자로 수정
- 해결2 : MapChangeEffect 가 VFXManager에 연결되어 있었고, VFX Manager는 싱글톤의 Generic T를 상속받는 중인데, VFXManager가 맵을 나갔다 오면 상기된 [원인]을 이유로 fake null 처리됨. 심지어 Generic T는 != 연산자의 보정이 들어가있지 않아서 오류났던 것을 수정

## 📸 스크린샷

https://github.com/user-attachments/assets/347c4fd8-f0ff-4ca8-a2f6-faf65178bd8a

## 💬 특이 사항 / 리뷰 요청
- 남은 버그들(버그들은 아니지만 좀 자잘한거) 노션에 올렸으니까 처리해주세요
- 슬슬 스토브 인디 올릴려고 준비중입니다 노션에 있는거 모두 수정되면 바로 진행하도록 하겠습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 싱글톤 인스턴스 관리 방식을 개선하여 게임 안정성을 강화했습니다.
  * 맵 전환 시 참조 처리 로직을 최적화했습니다.
  * 씬 재로드 시 발생할 수 있는 참조 무효화 문제를 해결했습니다.
  * 튜토리얼 표시 조건을 단순화하여 더욱 명확하게 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->